### PR TITLE
Clean up editors when chat session is disposed

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditingService.ts
@@ -179,6 +179,12 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 	killCurrentEditingSession() {
 		const currentSession = this._currentSessionObs.get();
 		if (currentSession) {
+			// Close any open editors associated with this session
+			const groupedEditors = this._findGroupedEditors();
+			for (const [group, editor] of groupedEditors) {
+				group.closeEditor(editor);
+			}
+
 			this._onDidDisposeEditingSession.fire(currentSession);
 			currentSession.dispose();
 			this._currentSessionObs.set(null, undefined);
@@ -578,6 +584,12 @@ class ChatEditingSession extends Disposable implements IChatEditingSession {
 	}
 
 	override dispose() {
+		if (this.editorPane) {
+			const input = this.editorPane.input;
+			if (input) {
+				input.dispose();
+			}
+		}
 		super.dispose();
 		this._onDidDispose.fire();
 	}


### PR DESCRIPTION
- Enhanced killCurrentEditingSession to close associated editors
- Added editor cleanup in ChatEditingSession dispose method
- Used existing _findGroupedEditors to locate editors to close

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
